### PR TITLE
Remove rbenv repo reference

### DIFF
--- a/libexec/cfenv-help
+++ b/libexec/cfenv-help
@@ -146,7 +146,7 @@ if [ -z "$1" ] || [ "$1" == "cfenv" ]; then
   print_summaries commands local global shell install uninstall rehash environment environments which whence
   echo
   echo "See \`cfenv help <command>' for information on a specific command."
-  echo "For full documentation, see: https://github.com/sstephenson/cfenv#readme"
+  echo "For full documentation, see: https://github.com/nebhale/cfenv#readme"
 else
   command="$1"
   if [ -n "$(command_path "$command")" ]; then


### PR DESCRIPTION
The `cfenv` command with no options shows help text that makes reference to the readme on `GitHub`.
Previously this text included a reference to `sstephenson`, the creator of `rbenv`, of which `cfenv`
is a fork. This change modifies that reference to be correct for `cfenv`.
